### PR TITLE
Fix HTML generated for block highlight

### DIFF
--- a/src/learning_zig/01-language-overview-1.html
+++ b/src/learning_zig/01-language-overview-1.html
@@ -451,7 +451,7 @@ pub fn main() void {
 
 	<p>which prints:</p>
 
-	{% highlight "text" %}
+	{% highlight text %}
 	struct{comptime year: comptime_int = 2023, comptime month: comptime_int = 8}
 	{% endhighlight %}
 

--- a/src/learning_zig/01-language-overview-1.html
+++ b/src/learning_zig/01-language-overview-1.html
@@ -39,7 +39,7 @@ pub const User = struct {
 
 	<p>This is a simple example, something you might be able to follow even if it's your first time seeing Zig. Still, we're going to go over it line by line.</p>
 
-	<aside>See the <a href="/learning_zig	/#install">installing zig</a> section to quickly get up and running.</aside>
+	<aside>See the <a href="/learning_zig/#install">installing zig</a> section to quickly get up and running.</aside>
 
 	<section>
 		<h2 tabindex=-1 id=importing><a href=#importing aria-hidden=true>Importing</a></h2>


### PR DESCRIPTION
Good morning/evening @karlseguin,

First of all, thanks for this amazing “Learning Zig” guide! While reading it, I noticed that the HTML code of one of the pages was incorrect:
```html
<pre class="language-"text""><code class="language-"text"">
```
Due to the quotation mark inside the class name, it is parsed by the browsers as `class="language-" text=""` instead of `class="language-text"`.

It seems to come from the usage of `{% highlight "text" %}` instead of `{% highlight text %}` in the file 01-language-overview-1.html, which this PR fixes.

While I was at it, I also removed the tabulation inside the link to the “Installing Zig” section.

Have a nice day,