### PR TITLE
need to add pub to call the method

### DIFF
--- a/src/learning_zig/01-language-overview-1.html
+++ b/src/learning_zig/01-language-overview-1.html
@@ -188,7 +188,7 @@ pub const User = struct {
 
 	pub const SUPER_POWER = 9000;
 
-	fn diagnose(user: User) void {
+	pub fn diagnose(user: User) void {
 		if (user.power >= SUPER_POWER) {
 			std.debug.print("it's over {d}!!!", .{SUPER_POWER});
 		}


### PR DESCRIPTION
without pub you get this error:
```
learning.zig:6:9: error: 'diagnose' is not marked 'pub'
    User.diagnose(user);
    ~~~~^~~~~~~~~
models/user.zig:9:5: note: declared here
    fn diagnose(user: User) void {
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```