### PR TITLE
Fix code for windows 08-coding_in_zig.html

### DIFF
--- a/src/learning_zig/08-coding_in_zig.html
+++ b/src/learning_zig/08-coding_in_zig.html
@@ -152,7 +152,7 @@ pub fn main() !void {
 			if (builtin.os.tag == .windows) {
 				// In Windows lines are terminated by \r\n.
 				// We need to strip out the \r
-				name = std.mem.trimRight(u8, name, "\r");
+				name = @constCast(std.mem.trimRight(u8, name, "\r"));
 			}
 			if (name.len == 0) {
 				break;
@@ -272,7 +272,7 @@ pub fn main() !void {
 			if (builtin.os.tag == .windows) {
 				// In Windows lines are terminated by \r\n.
 				// We need to strip out the \r
-				name = std.mem.trimRight(u8, name, "\r");
+				name = @constCast(std.mem.trimRight(u8, name, "\r"));
 			}
 			if (name.len == 0) {
 				break;


### PR DESCRIPTION
I don't know if this is proper solution but it made examples compile and run fine for me.
I was getting an error:
> error: expected type '[]u8', found '[]const u8'
>                 name = std.mem.trimRight(u8, name, "\r");
>                        ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
> note: cast discards const qualifier

It would be good if someone added an explanation about what is `@constCast` and why it's needed here, if it is needed.