### PR TITLE
fix posix.timeval

### DIFF
--- a/src/2024/2024-10-02-TCP-Server-In-Zig-Part-1-Single-Threaded.html
+++ b/src/2024/2024-10-02-TCP-Server-In-Zig-Part-1-Single-Threaded.html
@@ -218,7 +218,7 @@ defer posix.close(socket);
 std.debug.print("{} connected\n", .{client_address});
 
 // Added these two lines
-const timeout = posix.timeval{.sec = 2, .usec = 500_000};
+const timeout = posix.timeval{.tv_sec = 2, .tv_usec = 500_000};
 try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(timeout));
 
 const read = posix.read(socket, &buf) catch |err| {
@@ -246,7 +246,7 @@ const read = posix.read(socket, &buf) catch |err| {
 
 {% highlight zig %}
 // our existing read timeout
-const timeout = posix.timeval{.sec = 2, .usec = 500_000};
+const timeout = posix.timeval{.tv_sec = 2, .tv_usec = 500_000};
 try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(timeout));
 
 // add the write timeout
@@ -295,7 +295,7 @@ pub fn main() !void {
 
         std.debug.print("{} connected\n", .{client_address});
 
-        const timeout = posix.timeval{.sec = 2, .usec = 500_000};
+        const timeout = posix.timeval{.tv_sec = 2, .tv_usec = 500_000};
         try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(timeout));
         try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &std.mem.toBytes(timeout));
 

--- a/src/2024/2024-10-02-TCP-Server-In-Zig-Part-1-Single-Threaded.html
+++ b/src/2024/2024-10-02-TCP-Server-In-Zig-Part-1-Single-Threaded.html
@@ -295,7 +295,7 @@ pub fn main() !void {
 
         std.debug.print("{} connected\n", .{client_address});
 
-        const timeout = posix.timeval{.tv_sec = 2, .tv_usec = 500_000};
+        const timeout = posix.timeval{.sec = 2, .usec = 500_000};
         try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(timeout));
         try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &std.mem.toBytes(timeout));
 

--- a/src/2024/2024-10-02-TCP-Server-In-Zig-Part-1-Single-Threaded.html
+++ b/src/2024/2024-10-02-TCP-Server-In-Zig-Part-1-Single-Threaded.html
@@ -217,8 +217,8 @@ defer posix.close(socket);
 
 std.debug.print("{} connected\n", .{client_address});
 
-// Added these two lines
-const timeout = posix.timeval{.tv_sec = 2, .tv_usec = 500_000};
+// Added these two lines (.tv_sec and .tv_usec before zig 0.14.0)
+const timeout = posix.timeval{.sec = 2, .usec = 500_000};
 try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(timeout));
 
 const read = posix.read(socket, &buf) catch |err| {
@@ -246,7 +246,7 @@ const read = posix.read(socket, &buf) catch |err| {
 
 {% highlight zig %}
 // our existing read timeout
-const timeout = posix.timeval{.tv_sec = 2, .tv_usec = 500_000};
+const timeout = posix.timeval{.sec = 2, .usec = 500_000};
 try posix.setsockopt(socket, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(timeout));
 
 // add the write timeout


### PR DESCRIPTION
First of all, thank you sooooo much for your blog! I find it very interesting to learn more about zig :+1: 

Trying to implement you latest post, I encountered a compilation error with `posix.timeval`. 

I don't know if this is a change of zig 0.13.0 or if this is system specific (I am running linux): https://ziglang.org/documentation/master/std/#std.posix.timeval

In my case changing the fields to `tv_sec` and `tv_usec` solves the issue.