### PR TITLE
fix typo in pointers explanation section

### DIFF
--- a/src/learning_zig/04-pointers.html
+++ b/src/learning_zig/04-pointers.html
@@ -265,7 +265,7 @@ fn levelUp(user: *User) void {
 
 		<p>If <code>user</code> is a <code>*User</code>, then what is <code>&user</code>? It's a <code>**User</code>, or a <em>pointer to a pointer to a <code>User</code></em>. I can do this until one of us runs out of memory!</p>
 
-		<p>There <em>are</em> use-cases for multiple levels of indirection, but is isn't anything we need right now. The purpose of this section is to show that pointers aren't special, they're just a value, which is an address, and a type.</p>
+		<p>There <em>are</em> use-cases for multiple levels of indirection, but it isn't anything we need right now. The purpose of this section is to show that pointers aren't special, they're just a value, which is an address, and a type.</p>
 	</section>
 
 	<section>


### PR DESCRIPTION
this PR changes `"is isn't"` to `"it isn't"` to improve readability and grammar.