### PR TITLE
Fix error in 2024-10-15-TCP-Server-In-Zig-Part-5a-Poll.html

### DIFF
--- a/src/2024/2024-10-15-TCP-Server-In-Zig-Part-5a-Poll.html
+++ b/src/2024/2024-10-15-TCP-Server-In-Zig-Part-5a-Poll.html
@@ -500,9 +500,8 @@ fn accept(self: *Server, listener: posix.socket_t) !void {
 }
 
 fn removeClient(self: *Server, at: usize) void {
-    posix.close(client.socket);
-
     var client = self.clients[at];
+    posix.close(client.socket);
     client.deinit(self.allocator);
 
     // Swap the client we're removing with the last one


### PR DESCRIPTION
When the `removeClient` function is first introduced, the client variable is used before it is declared.