### PR TITLE
coding-in-zig: fix stdin prompt takes only one value and exits

### DIFF
--- a/src/learning_zig/08-coding_in_zig.html
+++ b/src/learning_zig/08-coding_in_zig.html
@@ -144,6 +144,8 @@ pub fn main() !void {
   while (true) : (i += 1) {
     try stdout.interface.print("Please enter a name: ", .{});
     var name = try stdin.interface.takeDelimiterExclusive('\n');
+    stdin.interface.toss(1); // discard the delimiter
+
     if (builtin.os.tag == .windows) {
       // In Windows lines are terminated by \r\n.
       // We need to strip out the \r
@@ -260,6 +262,8 @@ pub fn main() !void {
   while (true) : (i += 1) {
     try stdout.interface.print("Please enter a name: ", .{});
     var name = try stdin.interface.takeDelimiterExclusive('\n');
+    stdin.interface.toss(1); // discard the delimiter
+
     if (builtin.os.tag == .windows) {
       // In Windows lines are terminated by \r\n.
       // We need to strip out the \r


### PR DESCRIPTION
`Reader.takeDelimiterExclusive` doesn't seek past the delimiter, so the first iteration prompts for input, and the second prints the prompt and immediately consumes (nothing) until the leftover delimiter then hits `if (name.len == 0) { break; }` and exits. i had to explicitly toss the delimiter to get this example to work.