### PR TITLE
TCP Server Part 3 Bug : Fix ensureSpace call to always request 4 bytes

### DIFF
--- a/src/2024/2024-10-08-TCP-Server-In-Zig-Part-3-Minimizing-Writes-and-Reads.html
+++ b/src/2024/2024-10-08-TCP-Server-In-Zig-Part-3-Minimizing-Writes-and-Reads.html
@@ -156,7 +156,7 @@ const Reader = struct {
 
         if (unprocessed.len < 4) {
             // We always need at least 4 bytes of data (the length prefix)
-            self.ensureSpace(4 - unprocessed.len) catch unreachable;
+            self.ensureSpace(4) catch unreachable;
             return null;
         }
 


### PR DESCRIPTION
Blog Post: TCP Server in Zig - Part 3 - Minimizing Writes & Reads

Problem: Buffer spare space is calculated using `buf.len - start.`

- This represents total capacity after compaction, not the currently writable region (`buf.len - pos`).
- `4 - unprocessed.len` computes missing prefix bytes instead of ensuring the buffer has capacity for the full 4-byte length prefix.